### PR TITLE
(refactor): usage of upl resource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## Version 2.1.1
+
+### Refactor
+
+-   Usage of upl resource.
+
 ## Version 2.1.0
 
 ### Features

--- a/pdc-samenwerkende-catalogi.php
+++ b/pdc-samenwerkende-catalogi.php
@@ -4,7 +4,7 @@
  * Plugin Name:       PDC Samenwerkende Catalogi
  * Plugin URI:        https://www.openwebconcept.nl/
  * Description:       Plugin to create a XML feed according to the Samenwerkende Catalogi requirements.
- * Version:           2.1.0
+ * Version:           2.1.1
  * Author:            Yard | Digital Agency
  * Author URI:        https://www.yard.nl/
  * License:           GPL-3.0
@@ -19,7 +19,7 @@ use OWC\PDC\SamenwerkendeCatalogi\Foundation\Plugin;
 /**
  * If this file is called directly, abort.
  */
-if (!defined('WPINC')) {
+if (! defined('WPINC')) {
     die;
 }
 

--- a/src/SamenwerkendeCatalogi/Foundation/Plugin.php
+++ b/src/SamenwerkendeCatalogi/Foundation/Plugin.php
@@ -14,13 +14,12 @@ use YahnisElsts\PluginUpdateChecker\v5\PucFactory;
  */
 class Plugin extends BasePlugin
 {
-
     /**
      * Name of the plugin.
      *
      * @const string NAME
      */
-    const NAME = 'pdc-samenwerkende-catalogi';
+    public const NAME = 'pdc-samenwerkende-catalogi';
 
     /**
      * Version of the plugin.
@@ -28,7 +27,7 @@ class Plugin extends BasePlugin
      *
      * @const string VERSION
      */
-    const VERSION = '2.1.0';
+    public const VERSION = '2.1.1';
 
     protected function checkForUpdate()
     {

--- a/src/SamenwerkendeCatalogi/Models/ScItem.php
+++ b/src/SamenwerkendeCatalogi/Models/ScItem.php
@@ -33,7 +33,7 @@ class ScItem extends Item
     /**
      * @param array $doelgroepen
      * @param object $doelgroepTerm
-     * 
+     *
      * @return array
      */
     private function assignDoelgroepen($doelgroepen = [], $doelgroepTerm): array
@@ -58,9 +58,6 @@ class ScItem extends Item
         return $doelgroepen;
     }
 
-    /**
-     * @return string
-     */
     public function getUplName(): string
     {
         $uplName = get_post_meta($this->getID(), '_owc_pdc_upl_naam', true);
@@ -69,29 +66,34 @@ class ScItem extends Item
             $uplName = $this->getTitle();
         }
 
-        return $this->stripUpl($uplName);
+        return $uplName;
     }
 
-    /**
-     * @return string
-     */
+    public function getStrippedUplName(): string
+    {
+        return $this->stripUpl($this->getUplName());
+    }
+
     public function getUplResource(): string
     {
-        return 'http://standaarden.overheid.nl/owms/terms/' . $this->getUplName();
+        $uplResource = get_post_meta($this->getID(), '_owc_pdc_upl_resource', true);
+
+        if (empty($uplResource)) {
+            $uplResource = $this->getStrippedUplName();
+        }
+
+        return 'http://standaarden.overheid.nl/owms/terms/' . $uplResource;
     }
 
     /**
      * Strip upl to required format.
-     *
-     * @param string $string
-     * @return string
      */
     protected function stripUpl(string $string): string
     {
-        // replace all spaces with dashes.
+        // Replace all spaces with dashes.
         $string = str_replace(' ', '-', strtolower($string));
 
-        // replace all the characters except lowercase letters and dashes.
+        // Replace all the characters except lowercase letters and dashes.
         return preg_replace("/[^a-z|-]/", "", $string);
     }
 }


### PR DESCRIPTION
PR based on e-mail below:

```
Dag Martin,

We krijgen door aanpassingen in de inhoud niet voor elkaar dat de lijst door de UPL validator komt.

Ik ben in de code van de plugin (https://github.com/OpenWebconcept/plugin-pdc-samenwerkende-catalogi) gaan kijken en ben daar de functie stripUpl tegengekomen.

https://github.com/OpenWebconcept/plugin-pdc-samenwerkende-catalogi/blob/master/src/SamenwerkendeCatalogi/Models/ScItem.php#L89

Die functie vervangt in de productnaam alle spaties voor koppeltekens en zet alle kapitalen om naar onderkast letters. Het gevolg hiervan is dat dit niet meer overeenkomt met de namen in de xml die de validator gebruikt. Ik heb de code in de plugin lokaal aangepast en nu werkt het wel.

https://standaarden.overheid.nl/owms/terms/UniformeProductnaam.xml
Misschien dat er in de opzet van de xml iets verandert is?
```

